### PR TITLE
basic hash table implementation

### DIFF
--- a/hash_table.h
+++ b/hash_table.h
@@ -2,21 +2,96 @@
 #define HASH_TABLE_H_
 
 #include "wet2util.h"
-#include "dynamic_array.h"
 #include "linked_list.h"
 
 template<typename T>
 class HashTable {
     public:
-    HashTable();
+    HashTable():m_table(new List<T>[10]),m_size(0),m_buckets(10) {};
     ~HashTable();
 
     StatusType insert(int key, const T& value);
-    output_t<T*> get(int key);
-    output_t<T*> del(int key);// not necessary
+    output_t<T*> get(int key) const;
+    void print() const;
 
     private:
-    Array<List<T>> m_array;
+    List<T>* m_table;
+    int m_size;
+    int m_buckets;
+    void resize();
+    int hash(const T& value) const;
+    int hash(int key) const;
 };
+
+template<typename T>
+HashTable<T>::~HashTable(){
+    delete[] m_table;
+}
+
+template<typename T>
+output_t<T*> HashTable<T>::get(int key) const{
+    int index = hash(key);
+    typename List<T>::Node *current = m_table[index].firstNode();
+    while(current != nullptr){
+        if(current->data.getId() == key){
+            return &current->data;
+        }
+        current=current->next;
+    }
+    return StatusType::FAILURE;
+}
+
+template<typename T>
+StatusType HashTable<T>::insert(int key, const T& value){
+    if(get(key).status()==StatusType::SUCCESS){
+        return StatusType::FAILURE;
+    }
+    if(m_size == m_buckets){
+        resize();
+    }
+    int index = hash(key);
+    m_table[index].add(value);
+    m_size++;
+    return StatusType::SUCCESS;
+}
+
+template <typename T>
+void HashTable<T>::resize(){
+    int old_buckets = m_buckets;
+    m_buckets *= 2;
+    List<T>* newTable = new List<T>[m_buckets];
+    for(int i=0; i<old_buckets; i++){
+        typename List<T>::Node *current = m_table[i].firstNode();
+        while(current != nullptr){
+            int newIndex = hash(current->data);
+            newTable[newIndex].add(current->data);
+            current = current->next;
+        }
+    }
+    delete[] m_table;
+    m_table = newTable;
+}
+template <typename T>
+int HashTable<T>::hash(const T& value)const{
+    return value.getId()%m_buckets;
+}
+template <typename T>
+int HashTable<T>::hash(int key)const{
+    return key%m_buckets;
+}
+
+//for testing
+template <typename T>
+void HashTable<T>::print()const{
+    for(int i=0;i<m_buckets;i++){
+        typename List<T>::Node *current = m_table[i].firstNode();
+        std::cout << "[]-> ";
+        while(current != nullptr){
+            std::cout << current->data << " -> ";
+            current = current->next;
+        }
+        std::cout << std::endl;
+    }
+}
 
 #endif // HASH_TABLE_H_

--- a/linked_list.h
+++ b/linked_list.h
@@ -18,6 +18,9 @@ public:
 
     output_t<Node*> add(const T& value);
     output_t<T> first() const;
+    Node* firstNode() const{
+        return m_head;
+    }
     StatusType remove(Node* node);
     void printList() const;
     int size() const {


### PR DESCRIPTION
works fine with ints, still needs testing with more complex types.
it should be able to work with any type that has getId() method.
didn't use dynamic array because it copies the values to same indexes as in the old array, but in hash table we need to rehash and change indexes accordingly.
added simple method to linkedlist that returns the first node so that i can iterate over each list whenever needed.